### PR TITLE
Scaffold dataCollection core: CLI, config, HTTP retry layer, storage/provenance, and base schemas

### DIFF
--- a/dataCollection/cli.py
+++ b/dataCollection/cli.py
@@ -1,0 +1,83 @@
+import argparse
+import sys
+from pathlib import Path
+import yaml
+
+from common.utils import today_str
+from collectors.eth2 import Eth2Collector
+from collectors.cosmos import CosmosCollector
+from collectors.polkadot import PolkadotCollector
+from curators.common import Curator
+from features.build_validator_stats_daily import build_validator_stats_daily
+from features.build_trust_signals_daily import build_trust_signals_daily
+
+def load_cfg(path: str):
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def get_collector(chain_id: str, cfg: dict):
+    if chain_id == "eth2":
+        return Eth2Collector(cfg)
+    if chain_id == "cosmos":
+        return CosmosCollector(cfg)
+    if chain_id == "polkadot":
+        return PolkadotCollector(cfg)
+    raise ValueError(f"Unsupported chain_id {chain_id}")
+
+def main():
+    p = argparse.ArgumentParser("dataCollection")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # collect
+    c = sub.add_parser("collect", help="Collect RAW data")
+    c.add_argument("--config", default="config.yaml")
+    c.add_argument("--chain", required=True, choices=["eth2","cosmos","polkadot"])
+    c.add_argument("--what", default="blocks,validators,attestations,slashings")
+    c.add_argument("--start", type=int)
+    c.add_argument("--end", type=int)
+    c.add_argument("--limit", type=int)
+    c.add_argument("--date", default=today_str())
+
+    # curate
+    u = sub.add_parser("curate", help="Normalize RAW -> CURATED")
+    u.add_argument("--config", default="config.yaml")
+    u.add_argument("--chain", required=True, choices=["eth2","cosmos","polkadot"])
+    u.add_argument("--date", default=today_str())
+
+    # features
+    f = sub.add_parser("features", help="Build daily features")
+    f.add_argument("--config", default="config.yaml")
+    f.add_argument("--chain", required=True, choices=["eth2","cosmos","polkadot"])
+    f.add_argument("--date", default=today_str())
+
+    args = p.parse_args()
+    cfg = load_cfg(args.config)
+
+    # Resolve chain-specific cfg
+    chain_cfg = None
+    for c in cfg["chains"]:
+        if c["chain_id"] == args.chain:
+            chain_cfg = c
+            break
+    if not chain_cfg:
+        print(f"Chain {args.chain} not found in config.yaml", file=sys.stderr)
+        sys.exit(1)
+    chain_cfg = {**chain_cfg, "format": cfg.get("format","parquet"), "root": cfg.get("root",".")}
+
+    if args.cmd == "collect":
+        collector = get_collector(args.chain, chain_cfg)
+        datasets = [x.strip() for x in args.what.split(",") if x.strip()]
+        collector.collect(datasets=datasets, start=args.start, end=args.end, limit=args.limit, ingest_date=args.date)
+        return
+
+    if args.cmd == "curate":
+        Curator(chain_cfg).curate(ingest_date=args.date)
+        return
+
+    if args.cmd == "features":
+        build_validator_stats_daily(chain_cfg, date=args.date)
+        build_trust_signals_daily(chain_cfg, date=args.date)
+        return
+
+if __name__ == "__main__":
+    main()

--- a/dataCollection/common/http.py
+++ b/dataCollection/common/http.py
@@ -1,0 +1,13 @@
+from typing import Optional, Dict, Any
+import requests
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+
+class HTTPError(Exception): ...
+
+@retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=1, max=10),
+       retry=retry_if_exception_type((requests.RequestException,)))
+def get_json(url: str, params: Optional[Dict[str, Any]] = None, timeout: int = 30):
+    r = requests.get(url, params=params, timeout=timeout)
+    if r.status_code != 200:
+        raise HTTPError(f"GET {url} -> {r.status_code} {r.text[:200]}")
+    return r.json()

--- a/dataCollection/common/provenance.py
+++ b/dataCollection/common/provenance.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, asdict
+from typing import Optional, Dict, Any
+
+@dataclass
+class Provenance:
+    source: str
+    api_version: Optional[str]
+    collector: str
+    chain_id: str
+    network: str
+    dataset: str
+    rows: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/dataCollection/common/storage.py
+++ b/dataCollection/common/storage.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+import pandas as pd
+import json
+from datetime import datetime, timezone
+
+def ensure_dir(p: Path): p.mkdir(parents=True, exist_ok=True)
+
+def part_path(root: Path, layer: str, table: str, chain_id: str, network: str, date: str) -> Path:
+    return root / layer / table / f"chain_id={chain_id}" / f"network={network}" / f"date={date}"
+
+def write_rows(rows: List[Dict[str, Any]], out_dir: Path, fmt: str = "parquet", filename: str = "part-000"):
+    ensure_dir(out_dir)
+    if not rows: return
+    df = pd.DataFrame(rows)
+    if fmt == "csv":
+        df.to_csv(out_dir / f"{filename}.csv", index=False)
+    else:
+        df.to_parquet(out_dir / f"{filename}.parquet", index=False)
+
+def write_provenance(out_dir: Path, info: Dict[str, Any]):
+    ensure_dir(out_dir)
+    info["written_at_utc"] = int(datetime.now(timezone.utc).timestamp())
+    with open(out_dir / "provenance.json", "w", encoding="utf-8") as f:
+        json.dump(info, f, ensure_ascii=False, indent=2)

--- a/dataCollection/common/utils.py
+++ b/dataCollection/common/utils.py
@@ -1,0 +1,8 @@
+from datetime import datetime, timezone
+
+def to_unix(ts_iso: str) -> int:
+    from dateutil import parser as dt
+    return int(dt.parse(ts_iso).replace(tzinfo=None).astimezone(timezone.utc).timestamp())
+
+def today_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/dataCollection/config.yaml
+++ b/dataCollection/config.yaml
@@ -1,0 +1,20 @@
+# Output format + partitioning
+format: parquet  # parquet|csv
+root: "."        # where raw/ curated/ features/ live under dataCollection
+
+# Chains & endpoints
+chains:
+  - chain_id: eth2
+    network: mainnet
+    beacon: "http://localhost:5052"   # Prefer local node
+    lookback_slots: 512               # used when --limit not given
+
+  - chain_id: cosmos
+    network: cosmoshub-4
+    rest: "https://cosmos-api.polkachu.com"
+    lookback_blocks: 2000
+
+  - chain_id: polkadot
+    network: mainnet
+    ws: "wss://rpc.polkadot.io"
+    lookback_blocks: 1000

--- a/dataCollection/requirements.txt
+++ b/dataCollection/requirements.txt
@@ -1,0 +1,9 @@
+requests>=2.32.3
+pydantic>=2.7.0
+pandas>=2.2.2
+pyarrow>=17.0.0
+tqdm>=4.66.4
+tenacity>=9.0.0
+python-dateutil>=2.9.0.post0
+substrate-interface>=1.7.8
+numpy>=1.26.4


### PR DESCRIPTION
This PR bootstraps the dataCollection module with the foundational pieces needed to start ingesting and organizing chain data. It introduces a configurable CLI (cli.py) wired for collect/curate/features workflows, a project-wide config.yaml for endpoint/network and output settings, and a requirements.txt with minimal runtime deps. Core utilities are included: an HTTP helper with retries/backoff (http.py), partitioned Parquet/CSV writing and path helpers (storage.py), lightweight provenance recording (provenance.py), canonical data models for blocks/validators/attestations/penalties (schemas.py), and small time/format helpers (utils.py). Together, these establish consistent schemas, deterministic directory layouts, and reproducible writes, paving the way for adding chain-specific collectors (Eth2/Cosmos/Polkadot), curation steps, and feature builders in follow-up PRs. No breaking changes; functionality is limited to scaffolding and will be exercised once collectors are added.