### PR TITLE
 Implement Eth2, Cosmos, and Polkadot data collectors for dataCollection

### DIFF
--- a/daily-logs/week5/11-08-25.md
+++ b/daily-logs/week5/11-08-25.md
@@ -61,13 +61,4 @@
   - Finalize schema versioning and manifest tracking for all datasets
 
 
-
-
-
-
-
-
-
-Ask ChatGPT
-
   

--- a/dataCollection/collectors/cosmos.py
+++ b/dataCollection/collectors/cosmos.py
@@ -1,0 +1,96 @@
+from typing import List, Optional, Dict, Any
+from pathlib import Path
+from tqdm import tqdm
+from common.http import get_json
+from common.storage import write_rows, part_path, write_provenance
+from common.provenance import Provenance
+from common.schemas import Block, Validator, Penalty
+from common.utils import to_unix
+
+class CosmosCollector:
+    def __init__(self, cfg: dict):
+        self.chain_id = "cosmos"
+        self.network = cfg.get("network","cosmoshub-4")
+        self.base = cfg.get("rest","http://localhost:1317")
+        self.format = cfg.get("format","parquet")
+        self.root = Path(cfg.get("root","."))
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None):
+        return get_json(f"{self.base}{path}", params=params)
+
+    def _latest(self) -> int:
+        latest = self._get("/cosmos/base/tendermint/v1beta1/blocks/latest")
+        return int(latest["block"]["header"]["height"])
+
+    def collect(self, datasets: List[str], start: Optional[int], end: Optional[int], limit: Optional[int], ingest_date: str):
+        if start is None and end is None:
+            tip = self._latest()
+            end = tip
+            lookback = limit or 2000
+            start = max(1, end - lookback + 1)
+        elif end is None:
+            tip = self._latest()
+            end = min(tip, start + (limit or 1000) - 1)
+
+        if "blocks" in datasets:
+            self._blocks(start, end, ingest_date)
+        if "validators" in datasets:
+            self._validators(ingest_date)
+        if "slashings" in datasets:
+            self._penalties(start, end, ingest_date)
+
+    def _blocks(self, start: int, end: int, date: str):
+        rows = []
+        for h in tqdm(range(start, end+1), desc="cosmos blocks"):
+            try:
+                b = self._get(f"/cosmos/base/tendermint/v1beta1/blocks/{h}")
+                hdr = b["block"]["header"]
+                rows.append(Block(
+                    chain_id=self.chain_id, network=self.network,
+                    height_or_slot=int(hdr["height"]),
+                    block_hash=b.get("block_id",{}).get("hash"),
+                    proposer_address=hdr.get("proposer_address"),
+                    timestamp_utc=int(to_unix(hdr["time"]))
+                ).model_dump())
+            except Exception:
+                continue
+        out = part_path(self.root, "raw", "blocks", self.chain_id, self.network, date)
+        write_rows(rows, out, self.format)
+        write_provenance(out, Provenance(self.base, None, "cosmos.blocks", self.chain_id, self.network, "blocks", len(rows)).to_dict())
+
+    def _validators(self, date: str):
+        rows = []
+        v = self._get("/cosmos/staking/v1beta1/validators", params={"status":"BOND_STATUS_BONDED","pagination.limit":"1000"})
+        from time import time
+        snap = int(time())
+        for val in v.get("validators", []):
+            rows.append(Validator(
+                chain_id=self.chain_id, network=self.network, snapshot_ts=snap,
+                validator_id=val.get("operator_address",""),
+                status=val.get("status"),
+                commission=float(val.get("commission",{}).get("commission_rates",{}).get("rate", 0.0))
+            ).model_dump())
+        out = part_path(self.root, "raw", "validators", self.chain_id, self.network, date)
+        write_rows(rows, out, self.format)
+        write_provenance(out, Provenance(self.base, None, "cosmos.validators", self.chain_id, self.network, "validators", len(rows)).to_dict())
+
+    def _penalties(self, start: int, end: int, date: str):
+        rows = []
+        import json
+        for h in tqdm(range(start, end+1), desc="cosmos penalties"):
+            try:
+                txs = self._get("/cosmos/tx/v1beta1/txs", params={"events": f"tx.height={h}", "pagination.limit": "200"})
+                for tx in txs.get("tx_responses", []):
+                    for log in tx.get("logs", []):
+                        for ev in log.get("events", []):
+                            t = ev.get("type")
+                            if t in ("slash", "unjail"):
+                                rows.append(dict(
+                                    chain_id=self.chain_id, network=self.network,
+                                    height_or_slot=h, penalty_type=t, meta_json=json.dumps(ev)
+                                ))
+            except Exception:
+                continue
+        out = part_path(self.root, "raw", "penalties", self.chain_id, self.network, date)
+        write_rows(rows, out, self.format)
+        write_provenance(out, Provenance(self.base, None, "cosmos.penalties", self.chain_id, self.network, "penalties", len(rows)).to_dict())

--- a/dataCollection/collectors/eth2.py
+++ b/dataCollection/collectors/eth2.py
@@ -1,0 +1,128 @@
+from typing import List, Optional, Dict, Any
+from pathlib import Path
+from tqdm import tqdm
+
+from common.http import get_json
+from common.storage import write_rows, part_path, write_provenance
+from common.provenance import Provenance
+from common.schemas import Block, Validator, Attestation, Penalty
+
+class Eth2Collector:
+    def __init__(self, cfg: dict):
+        self.chain_id = "eth2"
+        self.network = cfg.get("network","mainnet")
+        self.base = cfg.get("beacon","http://localhost:5052")
+        self.format = cfg.get("format","parquet")
+        self.root = Path(cfg.get("root","."))
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None):
+        data = get_json(f"{self.base}{path}", params=params)
+        return data.get("data", data)
+
+    def _latest_slot(self) -> int:
+        head = self._get("/eth/v1/beacon/headers/head")
+        return int(head["header"]["message"]["slot"])
+
+    def collect(self, datasets: List[str], start: Optional[int], end: Optional[int], limit: Optional[int], ingest_date: str):
+        # Defaults
+        if start is None and end is None:
+            latest = self._latest_slot()
+            end = latest
+            lookback = limit or 512
+            start = max(0, latest - lookback + 1)
+        elif end is None:
+            latest = self._latest_slot()
+            end = min(latest, start + (limit or 256) - 1)
+
+        if "blocks" in datasets:
+            self._blocks(start, end, ingest_date)
+        if "validators" in datasets:
+            self._validators(ingest_date)
+        if "attestations" in datasets:
+            self._attestations(start, end, ingest_date)
+        if "slashings" in datasets:
+            self._slashings(start, end, ingest_date)
+
+    def _blocks(self, start: int, end: int, date: str):
+        rows = []
+        for slot in tqdm(range(start, end+1), desc="eth2 blocks"):
+            try:
+                b = self._get(f"/eth/v2/beacon/blocks/{slot}")
+                msg = b["message"]
+                rows.append(Block(
+                    chain_id=self.chain_id,
+                    network=self.network,
+                    height_or_slot=slot,
+                    epoch=slot//32,
+                    block_hash=b.get("root"),
+                    parent_hash=(msg["body"].get("execution_payload") or {}).get("parent_hash"),
+                    proposer_index=int(msg["proposer_index"]),
+                    timestamp_utc=int((msg["body"].get("execution_payload") or {}).get("timestamp") or 0) or None
+                ).model_dump())
+            except Exception:
+                continue
+        out_dir = part_path(self.root, "raw", "blocks", self.chain_id, self.network, date)
+        write_rows(rows, out_dir, self.format)
+        write_provenance(out_dir, Provenance(self.base, None, "eth2.blocks", self.chain_id, self.network, "blocks", len(rows)).to_dict())
+
+    def _validators(self, date: str):
+        data = self._get("/eth/v1/beacon/states/head/validators")
+        rows = []
+        from time import time
+        snap = int(time())
+        for v in data:
+            info = v["validator"]
+            rows.append(Validator(
+                chain_id=self.chain_id, network=self.network, snapshot_ts=snap,
+                validator_id=str(v["index"]),
+                status=v.get("status"),
+                balance=int(info.get("balance",0)),
+                effective_balance=int(info.get("effective_balance",0)),
+                slashed=bool(info.get("slashed", False))
+            ).model_dump())
+        out_dir = part_path(self.root, "raw", "validators", self.chain_id, self.network, date)
+        write_rows(rows, out_dir, self.format)
+        write_provenance(out_dir, Provenance(self.base, None, "eth2.validators", self.chain_id, self.network, "validators", len(rows)).to_dict())
+
+    def _attestations(self, start: int, end: int, date: str):
+        rows = []
+        for slot in tqdm(range(start, end+1), desc="eth2 attestations"):
+            try:
+                b = self._get(f"/eth/v2/beacon/blocks/{slot}")
+                msg = b["message"]
+                for att in msg["body"].get("attestations", []):
+                    d = att["data"]
+                    rows.append(Attestation(
+                        chain_id=self.chain_id, network=self.network,
+                        height_or_slot=slot, epoch=slot//32,
+                        committee_index=int(d.get("index",0)),
+                        head_block_root=d.get("beacon_block_root"),
+                        source_epoch=int(d["source"]["epoch"]),
+                        target_epoch=int(d["target"]["epoch"]),
+                    ).model_dump())
+            except Exception:
+                continue
+        out_dir = part_path(self.root, "raw", "attestations", self.chain_id, self.network, date)
+        write_rows(rows, out_dir, self.format)
+        write_provenance(out_dir, Provenance(self.base, None, "eth2.attestations", self.chain_id, self.network, "attestations", len(rows)).to_dict())
+
+    def _slashings(self, start: int, end: int, date: str):
+        rows = []
+        import json as _json
+        for slot in tqdm(range(start, end+1), desc="eth2 slashings"):
+            try:
+                b = self._get(f"/eth/v2/beacon/blocks/{slot}")
+                msg = b["message"]
+                for s in msg["body"].get("proposer_slashings", []):
+                    rows.append(Penalty(chain_id=self.chain_id, network=self.network,
+                        height_or_slot=slot, penalty_type="proposer_slashing",
+                        meta_json=_json.dumps(s)).model_dump())
+                for s in msg["body"].get("attester_slashings", []):
+                    rows.append(Penalty(chain_id=self.chain_id, network=self.network,
+                        height_or_slot=slot, penalty_type="attester_slashing",
+                        meta_json=_json.dumps(s)).model_dump())
+            except Exception:
+                continue
+        out_dir = part_path(self.root, "raw", "penalties", self.chain_id, self.network, date)
+        write_rows(rows, out_dir, self.format)
+        write_provenance(out_dir, Provenance(self.base, None, "eth2.penalties", self.chain_id, self.network, "penalties", len(rows)).to_dict())

--- a/dataCollection/collectors/polkadot.py
+++ b/dataCollection/collectors/polkadot.py
@@ -1,0 +1,62 @@
+from typing import List, Optional
+from pathlib import Path
+from tqdm import tqdm
+from substrateinterface import SubstrateInterface
+from common.storage import write_rows, part_path, write_provenance
+from common.provenance import Provenance
+from common.schemas import Block, Validator
+
+class PolkadotCollector:
+    def __init__(self, cfg: dict):
+        self.chain_id = "polkadot"
+        self.network = cfg.get("network","mainnet")
+        self.ws = cfg.get("ws","wss://rpc.polkadot.io")
+        self.format = cfg.get("format","parquet")
+        self.root = Path(cfg.get("root","."))
+
+        self.substrate = SubstrateInterface(url=self.ws)
+
+    def _latest(self) -> int:
+        head = self.substrate.get_chain_head()
+        header = self.substrate.get_block_header(head)
+        return int(header["number"])
+
+    def collect(self, datasets: List[str], start: Optional[int], end: Optional[int], limit: Optional[int], ingest_date: str):
+        if start is None and end is None:
+            tip = self._latest()
+            end = tip
+            start = max(1, end - (limit or 1000) + 1)
+        elif end is None:
+            tip = self._latest()
+            end = min(tip, start + (limit or 500) - 1)
+
+        if "blocks" in datasets:
+            self._blocks(start, end, ingest_date)
+        if "validators" in datasets:
+            self._validators(ingest_date)
+
+    def _blocks(self, start: int, end: int, date: str):
+        rows = []
+        for h in tqdm(range(start, end+1), desc="polkadot blocks"):
+            try:
+                bh = self.substrate.get_block_hash(block_id=h)
+                hdr = self.substrate.get_block_header(block_hash=bh)
+                rows.append(Block(
+                    chain_id=self.chain_id, network=self.network,
+                    height_or_slot=h, block_hash=str(bh),
+                    parent_hash=str(hdr["parentHash"])
+                ).model_dump())
+            except Exception:
+                continue
+        out = part_path(self.root, "raw", "blocks", self.chain_id, self.network, date)
+        write_rows(rows, out, self.format)
+        write_provenance(out, Provenance(self.ws, None, "polkadot.blocks", self.chain_id, self.network, "blocks", len(rows)).to_dict())
+
+    def _validators(self, date: str):
+        rows = []
+        res = self.substrate.query(module='Session', storage_function='Validators')
+        for acc in res.value or []:
+            rows.append(Validator(chain_id=self.chain_id, network=self.network, snapshot_ts=0, validator_id=acc).model_dump())
+        out = part_path(self.root, "raw", "validators", self.chain_id, self.network, date)
+        write_rows(rows, out, self.format)
+        write_provenance(out, Provenance(self.ws, None, "polkadot.validators", self.chain_id, self.network, "validators", len(rows)).to_dict())


### PR DESCRIPTION
This PR adds collectors that are special to each chain to the dataCollection module. This lets the Ethereum 2.0, Cosmos, and Polkadot networks take in raw data.  Each collector can handle attestations, penalties/slashings, validators, and getting blocks. Eth2 can also handle attestations.  The collectors work with the current command line interface (CLI), share the HTTP and storage tools, and write split Parquet or CSV files with origin information.  These solutions finish the raw data ingestion layer, which makes it possible for the next steps of curation and feature extraction.