### PR TITLE
Add Curator Modules, Feature Builders, and Metadata Schema Tracking to dataCollection

### DIFF
--- a/dataCollection/curators/common.py
+++ b/dataCollection/curators/common.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import pandas as pd
+from common.storage import ensure_dir, part_path, write_rows
+from common.utils import today_str
+
+class Curator:
+    """
+    Minimal normalizer:
+      - block_core
+      - validator_core
+      - attestation_core
+      - penalty_core
+    """
+    def __init__(self, cfg: dict):
+        self.chain_id = cfg["chain_id"]
+        self.network = cfg["network"]
+        self.root = Path(cfg.get("root","."))
+        self.format = cfg.get("format","parquet")
+
+    def _read_any(self, layer: str, table: str, date: str) -> pd.DataFrame:
+        base = part_path(self.root, layer, table, self.chain_id, self.network, date)
+        if not base.exists(): return pd.DataFrame()
+        files = list(base.glob("*.parquet")) + list(base.glob("*.csv"))
+        if not files: return pd.DataFrame()
+        dfs = []
+        for f in files:
+            if f.suffix == ".csv":
+                dfs.append(pd.read_csv(f))
+            else:
+                dfs.append(pd.read_parquet(f))
+        return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+
+    def curate(self, ingest_date: str):
+        date = ingest_date or today_str()
+
+        # blocks -> block_core
+        raw_blocks = self._read_any("raw", "blocks", date)
+        if not raw_blocks.empty:
+            out = part_path(self.root, "curated", "block_core", self.chain_id, self.network, date)
+            # rename/ensure columns
+            cols = ["chain_id","network","height_or_slot","epoch","block_hash","parent_hash","proposer_index","proposer_address","timestamp_utc"]
+            for c in cols:
+                if c not in raw_blocks.columns:
+                    raw_blocks[c] = None
+            write_rows(raw_blocks[cols].drop_duplicates(subset=["chain_id","network","height_or_slot"]), out, self.format)
+
+        # validators -> validator_core
+        raw_vals = self._read_any("raw", "validators", date)
+        if not raw_vals.empty:
+            out = part_path(self.root, "curated", "validator_core", self.chain_id, self.network, date)
+            cols = ["chain_id","network","snapshot_ts","validator_id","status","balance","effective_balance","commission","slashed"]
+            for c in cols:
+                if c not in raw_vals.columns:
+                    raw_vals[c] = None
+            # PK uniqueness
+            raw_vals = raw_vals.drop_duplicates(subset=["chain_id","network","snapshot_ts","validator_id"])
+            write_rows(raw_vals[cols], out, self.format)
+
+        # attestations -> attestation_core
+        raw_atts = self._read_any("raw", "attestations", date)
+        if not raw_atts.empty:
+            out = part_path(self.root, "curated", "attestation_core", self.chain_id, self.network, date)
+            cols = ["chain_id","network","height_or_slot","epoch","committee_index","head_block_root","source_epoch","target_epoch"]
+            for c in cols:
+                if c not in raw_atts.columns: raw_atts[c] = None
+            raw_atts = raw_atts.drop_duplicates(subset=["chain_id","network","height_or_slot","committee_index","head_block_root"])
+            write_rows(raw_atts[cols], out, self.format)
+
+        # penalties -> penalty_core
+        raw_pen = self._read_any("raw", "penalties", date)
+        if not raw_pen.empty:
+            out = part_path(self.root, "curated", "penalty_core", self.chain_id, self.network, date)
+            cols = ["chain_id","network","height_or_slot","validator_id","penalty_type","value","meta_json"]
+            for c in cols:
+                if c not in raw_pen.columns: raw_pen[c] = None
+            write_rows(raw_pen[cols].drop_duplicates(), out, self.format)

--- a/dataCollection/features/build_trust_signals_daily.py
+++ b/dataCollection/features/build_trust_signals_daily.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from common.storage import part_path, write_rows
+
+def _z(x):
+    if len(x) == 0: return x
+    mu, sd = np.nanmean(x), np.nanstd(x)
+    if sd == 0 or np.isnan(sd): return np.zeros_like(x)
+    return (x - mu) / sd
+
+def build_trust_signals_daily(cfg: dict, date: str):
+    root = Path(cfg.get("root","."))
+    chain = cfg["chain_id"]
+    net = cfg["network"]
+    fmt = cfg.get("format","parquet")
+
+    stats_p = part_path(root, "features", "validator_stats_daily", chain, net, date)
+    files = list(stats_p.glob("*.parquet")) + list(stats_p.glob("*.csv"))
+    if not files: return
+    df = pd.read_parquet(files[0]) if files[0].suffix==".parquet" else pd.read_csv(files[0])
+
+    # Simple composite: z(attestation_rate) + 0.5*z(proposed_blocks)
+    df["z_att"] = _z(df["attestation_rate"].astype(float))
+    df["z_prop"] = _z(df["proposed_blocks"].astype(float))
+    df["trust_score_v1"] = df["z_att"] + 0.5*df["z_prop"]
+
+    out_rows = df[["chain_id","network","date","validator_id","trust_score_v1"]].to_dict(orient="records")
+    out_dir = part_path(root, "features", "trust_signals_daily", chain, net, date)
+    write_rows(out_rows, out_dir, fmt)

--- a/dataCollection/features/build_validator_stats_daily.py
+++ b/dataCollection/features/build_validator_stats_daily.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from common.storage import part_path, write_rows
+
+def build_validator_stats_daily(cfg: dict, date: str):
+    root = Path(cfg.get("root","."))
+    chain = cfg["chain_id"]
+    net = cfg["network"]
+    fmt = cfg.get("format","parquet")
+
+    # Inputs
+    vals_p = part_path(root, "curated", "validator_core", chain, net, date)
+    atts_p = part_path(root, "curated", "attestation_core", chain, net, date)
+    blocks_p = part_path(root, "curated", "block_core", chain, net, date)
+
+    def read_any(p: Path):
+        if p.exists():
+            fs = list(p.glob("*.parquet")) + list(p.glob("*.csv"))
+            if not fs: return pd.DataFrame()
+            dfs = [pd.read_parquet(f) if f.suffix==".parquet" else pd.read_csv(f) for f in fs]
+            return pd.concat(dfs, ignore_index=True)
+        return pd.DataFrame()
+
+    vals = read_any(vals_p)
+    atts = read_any(atts_p)
+    blocks = read_any(blocks_p)
+
+    # Minimal heuristic features (will refine later)
+    out_rows = []
+    if not vals.empty:
+        # Counts
+        proposed_blocks = 0
+        if not blocks.empty and "proposer_index" in blocks.columns and blocks["proposer_index"].notna().any():
+            # Only available for eth2
+            by_prop = blocks.groupby("proposer_index").size().to_dict()
+        else:
+            by_prop = {}
+
+        # Attestation stats (eth2 only)
+        if not atts.empty:
+            total_atts = len(atts)
+            att_rate = 1.0  # per-validator normalization not available without validator_index expansion
+        else:
+            total_atts = 0
+            att_rate = np.nan
+
+        for _, v in vals.iterrows():
+            out_rows.append(dict(
+                chain_id=chain, network=net, date=date, validator_id=str(v["validator_id"]),
+                attestation_rate=att_rate,
+                avg_inclusion_delay=np.nan,   # needs committee expansion
+                missed_attestations=np.nan,   # requires per-validator trace
+                proposed_blocks=by_prop.get(int(v["validator_id"]) if str(v["validator_id"]).isdigit() else -1, 0),
+                slash_count_30d=np.nan,
+                stake_share=np.nan,
+                churn_events_30d=np.nan,
+                uptime_estimate=np.nan
+            ))
+
+    out_dir = part_path(root, "features", "validator_stats_daily", chain, net, date)
+    write_rows(out_rows, out_dir, fmt)

--- a/dataCollection/metadata/schema_versions.json
+++ b/dataCollection/metadata/schema_versions.json
@@ -1,0 +1,8 @@
+{
+  "block_core": 1,
+  "validator_core": 1,
+  "attestation_core": 1,
+  "penalty_core": 1,
+  "validator_stats_daily": 1,
+  "trust_signals_daily": 1
+}


### PR DESCRIPTION
This PR extends the dataCollection pipeline by introducing the curation, feature generation, and metadata components necessary to transform raw blockchain data into analytics-ready datasets. The new curator modules normalize raw data for blocks, validators, attestations, and penalties into standardized curated tables, ensuring consistent schemas across chains. Two feature builders—validator_stats_daily and trust_signals_daily—have been implemented to produce daily validator performance metrics and initial trust score calculations. Additionally, a metadata folder with a draft schema_versions.json has been added to manage dataset versioning and schema evolution tracking. These additions complete the second stage of the ingestion pipeline, preparing the system for end-to-end testing and advanced model integration.