### PR TITLE
Add Config Validation for Trust and Q-Learning Parameters

### DIFF
--- a/codes/config.py
+++ b/codes/config.py
@@ -38,3 +38,24 @@ class Config:
     def epsilon(self) -> float:
         # Alias to maintain old API: return initial epsilon value
         return self.epsilon_start
+    def __post_init__(self):
+        # Trust-related params
+        if not (0.0 <= self.initial_trust <= 1.0):
+            raise ValueError(f"initial_trust must be in [0.0, 1.0], got {self.initial_trust}")
+        if not (0.0 <= self.trust_decay <= 1.0):
+            raise ValueError(f"trust_decay must be in [0.0, 1.0], got {self.trust_decay}")
+        if not (0.0 <= self.trust_reward_weight <= 1.0):
+            raise ValueError(f"trust_reward_weight must be in [0.0, 1.0], got {self.trust_reward_weight}")
+        if not (0.0 <= self.trust_penalty_weight <= 1.0):
+            raise ValueError(f"trust_penalty_weight must be in [0.0, 1.0], got {self.trust_penalty_weight}")
+        # Q-learning checks
+        if not (0.0 < self.learning_rate <= 1.0):
+            raise ValueError(f"learning_rate must be in (0.0, 1.0], got {self.learning_rate}")
+        if not (0.0 < self.gamma <= 1.0):
+            raise ValueError(f"gamma (discount factor) must be in (0.0, 1.0], got {self.gamma}")
+        if not (0.0 <= self.epsilon_min <= 1.0):
+            raise ValueError(f"epsilon_min must be in [0.0, 1.0], got {self.epsilon_min}")
+        if not (0.0 <= self.epsilon_start <= 1.0):
+            raise ValueError(f"epsilon_start must be in [0.0, 1.0], got {self.epsilon_start}")
+        if not (0.0 < self.epsilon_decay <= 1.0):
+            raise ValueError(f"epsilon_decay must be in (0.0, 1.0], got {self.epsilon_decay}")


### PR DESCRIPTION
Here’s a PR description tailored for **Shakir**, following verbosity=0.35, coverage=0.7, structure=0.6:

---

## PR: Add Config Validation for Trust and Q-Learning Parameters

This update strengthens the configuration class by introducing validation checks to ensure parameter consistency and prevent invalid setups.

### Key Updates

* **Trust-related validation**

  * Ensures `initial_trust`, `trust_decay`, `trust_reward_weight`, and `trust_penalty_weight` stay within the \[0.0, 1.0] range.
* **Q-learning safeguards**

  * Added strict bounds for `learning_rate`, `gamma`, `epsilon_start`, `epsilon_min`, and `epsilon_decay`.
  * Early error raising improves transparency during initialization.

### Secondary Adjustments

* Centralized all validation logic inside `__post_init__` for cleaner config handling.
* Error messages now provide clear parameter feedback when out of range.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added runtime validation for configuration values, providing clear error messages when settings are out of allowed ranges.
  - Enforces sensible 0–1 ranges for trust parameters and Q-learning settings (e.g., learning rate, gamma, epsilon, decay).
  - Prevents misconfiguration by catching issues at startup; valid configurations continue to work as before.
  - No changes required to existing workflows—only invalid values will be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->