### PR TITLE
Strengthen Config and Trust Handling

### DIFF
--- a/codes/agent/marl_agent.py
+++ b/codes/agent/marl_agent.py
@@ -42,7 +42,14 @@ class MARLAgent(BaseAgent):
         self.state = next_state
 
     def update_trust_score(self, uptime, missed_blocks, slashed):
-        self.trust = update_trust(self.trust, uptime, missed_blocks, slashed)
+        self.trust = update_trust(
+            self.trust,
+            uptime,
+            missed_blocks,
+            slashed,
+            reward_weight=getattr(self.cfg, 'trust_reward_weight', 0.7),
+            penalty_weight=getattr(self.cfg, 'trust_penalty_weight', 0.3)
+        )
         # cache for explanations
         self.last_uptime = float(uptime)
         self.last_missed_blocks = int(missed_blocks)

--- a/codes/agent/trust_score.py
+++ b/codes/agent/trust_score.py
@@ -1,7 +1,7 @@
 # trust_score.py - generated as part of modular structure
 
 
-def update_trust(current_trust, uptime, missed_blocks, slashed):
+def update_trust(current_trust, uptime, missed_blocks, slashed, reward_weight=0.7, penalty_weight=0.3):
     """
     Update the trust score of a validator based on performance metrics.
 
@@ -10,18 +10,15 @@ def update_trust(current_trust, uptime, missed_blocks, slashed):
     - uptime (float): Uptime in percentage (0.0 to 1.0)
     - missed_blocks (int): Number of missed blocks
     - slashed (bool): Whether the validator was slashed
+    - reward_weight (float): Weight for uptime reward (default 0.7)
+    - penalty_weight (float): Weight for missed blocks penalty (default 0.3)
 
     Returns:
     - float: Updated trust score (0.0 to 1.0)
     """
     trust = current_trust
-
     if slashed:
         trust *= 0.5  # Severe penalty
-
-    trust += (uptime * 0.05)  # Reward for uptime
-    trust -= (missed_blocks * 0.01)  # Penalty for missed blocks
-
-    # Clamp value between 0 and 1
+    trust += reward_weight * uptime - penalty_weight * (missed_blocks / 10.0)
     trust = max(0.0, min(1.0, trust))
     return trust

--- a/codes/config.py
+++ b/codes/config.py
@@ -38,3 +38,24 @@ class Config:
     def epsilon(self) -> float:
         # Alias to maintain old API: return initial epsilon value
         return self.epsilon_start
+    def __post_init__(self):
+        # Trust-related params
+        if not (0.0 <= self.initial_trust <= 1.0):
+            raise ValueError(f"initial_trust must be in [0.0, 1.0], got {self.initial_trust}")
+        if not (0.0 <= self.trust_decay <= 1.0):
+            raise ValueError(f"trust_decay must be in [0.0, 1.0], got {self.trust_decay}")
+        if not (0.0 <= self.trust_reward_weight <= 1.0):
+            raise ValueError(f"trust_reward_weight must be in [0.0, 1.0], got {self.trust_reward_weight}")
+        if not (0.0 <= self.trust_penalty_weight <= 1.0):
+            raise ValueError(f"trust_penalty_weight must be in [0.0, 1.0], got {self.trust_penalty_weight}")
+        # Q-learning checks
+        if not (0.0 < self.learning_rate <= 1.0):
+            raise ValueError(f"learning_rate must be in (0.0, 1.0], got {self.learning_rate}")
+        if not (0.0 < self.gamma <= 1.0):
+            raise ValueError(f"gamma (discount factor) must be in (0.0, 1.0], got {self.gamma}")
+        if not (0.0 <= self.epsilon_min <= 1.0):
+            raise ValueError(f"epsilon_min must be in [0.0, 1.0], got {self.epsilon_min}")
+        if not (0.0 <= self.epsilon_start <= 1.0):
+            raise ValueError(f"epsilon_start must be in [0.0, 1.0], got {self.epsilon_start}")
+        if not (0.0 < self.epsilon_decay <= 1.0):
+            raise ValueError(f"epsilon_decay must be in (0.0, 1.0], got {self.epsilon_decay}")

--- a/codes/main.py
+++ b/codes/main.py
@@ -40,7 +40,11 @@ def train():
             s2, reward, done, info = env.step_agent(a.agent_id, action)
             a.update(s2, reward, done)
             # Use missed_att + missed_prop as a simple "missed blocks" proxy
-            a.update_trust_score(info["uptime"], info["missed_att"] + info["missed_prop"], info["slashed"])
+            a.update_trust_score(
+                info["uptime"],
+                info["missed_att"] + info["missed_prop"],
+                info["slashed"]
+            )
             a.decay_epsilon()
             trusts.append(a.trust)
         avg_trust = sum(trusts) / len(trusts)

--- a/codes/train.py
+++ b/codes/train.py
@@ -8,6 +8,9 @@ from agent.trust_score import update_trust
 import utils  # to be implemented next, and this file will be updated regularly on the necessity of the required reusable fuctions
 import os
 
+# train.py - Thin wrapper to call codes.main.train() for consistency with the main pipeline.
+from codes.main import train
+
 def train():
     # Load configuration
     config = Config()
@@ -45,8 +48,8 @@ def train():
                     uptime=env.get_uptime(vid),
                     missed_blocks=env.get_missed_blocks(vid),
                     slashed=env.get_slashed(vid),
-                    reward_weight=getattr(config, 'trust_reward_weight', 0.7),
-                    penalty_weight=getattr(config, 'trust_penalty_weight', 0.3)
+                    reward_weight=getattr(config, 'trust_reward_weight', 0.7)
+                    # penalty_weight=getattr(config, 'trust_penalty_weight', 0.3)
                 )
 
             if done:

--- a/codes/train.py
+++ b/codes/train.py
@@ -44,7 +44,9 @@ def train():
                     current_trust=trust_scores[vid],
                     uptime=env.get_uptime(vid),
                     missed_blocks=env.get_missed_blocks(vid),
-                    slashed=env.get_slashed(vid)
+                    slashed=env.get_slashed(vid),
+                    reward_weight=getattr(config, 'trust_reward_weight', 0.7),
+                    penalty_weight=getattr(config, 'trust_penalty_weight', 0.3)
                 )
 
             if done:


### PR DESCRIPTION
- Added `__post_init__` in Config for strict parameter checks.
- Refactored `update_trust` to use reward and penalty weights.
- MARLAgent now passes trust weights correctly.
- Updated training and main loops to align with the new trust logic.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable trust weights for reward and penalty (defaults: reward 0.7, penalty 0.3) to tune how uptime and missed blocks affect trust.
  - Configuration validation prevents invalid trust and learning parameter values at startup.
- Refactor
  - Trust calculation consolidated into a single weighted formula while keeping clamping and severe slashing penalties.
- Chores
  - Minor callsite adjustments and a thin wrapper import with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->